### PR TITLE
feat: notificações push

### DIFF
--- a/src/entities/CanalDeNotificacao.ts
+++ b/src/entities/CanalDeNotificacao.ts
@@ -1,0 +1,21 @@
+export type IToken = {
+  userId: string
+  expoToken: string
+}
+
+interface ICanalAttributes {
+  id: string
+  nome: string
+}
+
+export type ICanalDeNotificacao = ICanalAttributes
+
+export default class CanalNotificacao implements ICanalDeNotificacao {
+  public id: string
+  public nome: string
+
+  constructor({ id, nome }: ICanalAttributes) {
+    this.id = id
+    this.nome = nome
+  }
+}

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -9,6 +9,7 @@ interface IUserAttributes {
   novidadeDispensada?(slug: string): boolean
   lastAccess?: Date
   countAccess?: number
+  canaisDeNotificacao?: Array<string>
 }
 
 export type IUser = IUserAttributes
@@ -23,6 +24,7 @@ export default class User implements IUser {
   public novidadesDispensadas: Array<string>
   public lastAccess?: Date
   public countAccess?: number
+  public canaisDeNotificacao?: Array<string>
 
   constructor({
     id,
@@ -33,7 +35,8 @@ export default class User implements IUser {
     role,
     novidadesDispensadas,
     lastAccess,
-    countAccess
+    countAccess,
+    canaisDeNotificacao,
   }: IUserAttributes) {
     this.id = id
     this.nome = nome
@@ -44,6 +47,7 @@ export default class User implements IUser {
     this.novidadesDispensadas = novidadesDispensadas
     this.lastAccess = lastAccess
     this.countAccess = countAccess
+    this.canaisDeNotificacao = canaisDeNotificacao
   }
 
   novidadeDispensada(slug: string): boolean {

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -10,6 +10,7 @@ interface IUserAttributes {
   lastAccess?: Date
   countAccess?: number
   canaisDeNotificacao?: Array<string>
+  tokens?: Array<string>
 }
 
 export type IUser = IUserAttributes
@@ -25,6 +26,7 @@ export default class User implements IUser {
   public lastAccess?: Date
   public countAccess?: number
   public canaisDeNotificacao?: Array<string>
+  public tokens?: Array<string>
 
   constructor({
     id,
@@ -37,6 +39,7 @@ export default class User implements IUser {
     lastAccess,
     countAccess,
     canaisDeNotificacao,
+    tokens
   }: IUserAttributes) {
     this.id = id
     this.nome = nome
@@ -48,6 +51,7 @@ export default class User implements IUser {
     this.lastAccess = lastAccess
     this.countAccess = countAccess
     this.canaisDeNotificacao = canaisDeNotificacao
+    this.tokens = tokens
   }
 
   novidadeDispensada(slug: string): boolean {

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -16,6 +16,7 @@ export default class UserFactory {
       role,
       novidadesDispensadas,
       canaisDeNotificacao,
+      tokens
     } = dados
 
     const lastAccess = dados.lastAccess ? dados.lastAccess.toDate() : null
@@ -32,6 +33,7 @@ export default class UserFactory {
       lastAccess: lastAccess,
       countAccess: countAccess,
       canaisDeNotificacao: canaisDeNotificacao || [],
+      tokens: tokens || []
     })
   }
 }

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -8,8 +8,15 @@ export default class UserFactory {
   build(userSnapshot: any): IUser {
     const { id } = userSnapshot
     const dados = userSnapshot.data()
-    const { nome, email, temLivro, objetivos, role, novidadesDispensadas } =
-      dados
+    const {
+      nome,
+      email,
+      temLivro,
+      objetivos,
+      role,
+      novidadesDispensadas,
+      canaisDeNotificacao,
+    } = dados
 
     const lastAccess = dados.lastAccess ? dados.lastAccess.toDate() : null
     const countAccess = dados.countAccess ? dados.countAccess : 0
@@ -23,7 +30,8 @@ export default class UserFactory {
       role,
       novidadesDispensadas: novidadesDispensadas || [],
       lastAccess: lastAccess,
-      countAccess: countAccess
+      countAccess: countAccess,
+      canaisDeNotificacao: canaisDeNotificacao || [],
     })
   }
 }

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -167,7 +167,11 @@ const en = {
     novo: 'New'
   },
   notificacoes: {
-    tresDias: `Hi, it's been a while! How are you feeling today?`
+    tresDias: `Hi, it's been a while! How are you feeling today?`,
+    canais: {
+      geral: 'Solar Journey Events',
+      novasMeditacoes: 'New meditations'
+    }
   }
 }
 export default en

--- a/src/i18n/translations/pt.ts
+++ b/src/i18n/translations/pt.ts
@@ -167,7 +167,11 @@ const pt = {
     novo: 'Novo'
   },
   notificacoes: {
-    tresDias: 'Ei, já faz um tempo. Como você está se sentindo hoje?'
+    tresDias: 'Ei, já faz um tempo. Como você está se sentindo hoje?',
+    canais: {
+      geral: 'Eventos do Jornada Solar',
+      novasMeditacoes: 'Novas meditações'
+    }
   }
 }
 export default pt

--- a/src/repositories/CanalDeNotificacaoRepository.ts
+++ b/src/repositories/CanalDeNotificacaoRepository.ts
@@ -1,0 +1,34 @@
+import { ICanalDeNotificacao } from '../entities/CanalDeNotificacao'
+import { firestore } from '../firebase/firebase.config'
+
+export interface ICanalDeNotificacaoRepository {
+  getCanais(): Promise<Array<ICanalDeNotificacao>>
+}
+
+export default class CanalDeNotificacaoRepository
+  implements ICanalDeNotificacaoRepository
+{
+  private collection
+
+  constructor() {
+    this.collection = firestore.collection('canaisDeNotificacao')
+  }
+  async getCanais(): Promise<ICanalDeNotificacao[]> {
+    try {
+      const snapshot = await this.collection.get()
+
+      const canais: ICanalDeNotificacao[] = []
+
+      snapshot.forEach(canal => {
+        canais.push({ id: canal.id, nome: canal.data().nome })
+      })
+
+      return canais
+    } catch (error) {
+      throw new Error(
+        'Ocorreu um erro inesperado ao buscar os canais de notificação: ' +
+          error
+      )
+    }
+  }
+}

--- a/src/repositories/UsersRepository.ts
+++ b/src/repositories/UsersRepository.ts
@@ -11,6 +11,7 @@ import CreateOrUpdateRegistro from '../services/registros/CreateOrUpdateRegistro
 import GetUserSentimentos from '../services/user/GetUserSentimentos'
 import UserFactory, { IUserFactory } from '../factories/UserFactory'
 import { isSameDay } from 'date-fns'
+import GetAllCanais from '../services/notificacoes/getAllCanais'
 
 interface ICreateParameters {
   nome: string
@@ -29,7 +30,7 @@ interface IUpdateParameters {
 export interface IUsersRepository {
   add(params): Promise<IUser>
   getById(id: string): Promise<IUser>
-  update(params): boolean
+  update(params: IUpdateParameters): boolean
   updateAccessFlags(user: IUser): boolean
 }
 
@@ -59,6 +60,9 @@ export default class UsersRepository implements IUsersRepository {
       displayName: nome
     })
 
+    const canais = await new GetAllCanais().call()
+    const idsCanais = canais.map(canal => canal.id)
+
     // Cria usuário na collection user
     const data = {
       nome,
@@ -68,7 +72,8 @@ export default class UsersRepository implements IUsersRepository {
       created_at: now,
       updated_at: now,
       lastAccess: now,
-      countAccess: 1
+      countAccess: 1,
+      canaisDeNotificacao: idsCanais,
     }
     await this.collection.doc(user.uid).set(data)
 

--- a/src/repositories/UsersRepository.ts
+++ b/src/repositories/UsersRepository.ts
@@ -12,6 +12,7 @@ import GetUserSentimentos from '../services/user/GetUserSentimentos'
 import UserFactory, { IUserFactory } from '../factories/UserFactory'
 import { isSameDay } from 'date-fns'
 import GetAllCanais from '../services/notificacoes/getAllCanais'
+import { registraTokenParaNotificacoesExternas } from '../utils/notificacoes'
 
 interface ICreateParameters {
   nome: string
@@ -60,8 +61,10 @@ export default class UsersRepository implements IUsersRepository {
       displayName: nome
     })
 
+    // Inscreve o usuário em todos os canais de notificação e registra o ExpoToken
     const canais = await new GetAllCanais().call()
     const idsCanais = canais.map(canal => canal.id)
+    const token = await registraTokenParaNotificacoesExternas()
 
     // Cria usuário na collection user
     const data = {
@@ -74,6 +77,7 @@ export default class UsersRepository implements IUsersRepository {
       lastAccess: now,
       countAccess: 1,
       canaisDeNotificacao: idsCanais,
+      tokens: [token]
     }
     await this.collection.doc(user.uid).set(data)
 

--- a/src/screens/app/Diario.tsx
+++ b/src/screens/app/Diario.tsx
@@ -27,7 +27,7 @@ import getSigno from '../../utils/getSigno'
 import { useFocusEffect } from '@react-navigation/core'
 import Novidade from '../../components/Novidade'
 import Telas from '../../enums/Telas'
-import RegistrarAccesso from '../../services/user/RegistrarAcesso'
+import RegistrarAcesso from '../../services/user/RegistrarAcesso'
 
 const Diario = ({ navigation }: AppNavigationProps) => {
   const { userName, userId, user } = useContext(AuthContext)
@@ -53,7 +53,7 @@ const Diario = ({ navigation }: AppNavigationProps) => {
 
   useFocusEffect(
     React.useCallback(() => {
-      new RegistrarAccesso().call(user)
+      new RegistrarAcesso().call(user)
       setIsFocused(true)
       return () => setIsFocused(false)
     }, [])

--- a/src/screens/app/perfil/Notificacoes.tsx
+++ b/src/screens/app/perfil/Notificacoes.tsx
@@ -1,39 +1,98 @@
 import { t } from 'i18n-js'
-import React, { useState } from 'react'
-import { View } from 'react-native'
-import { Button, Switch } from 'react-native-paper'
-import NavigationList from '../../../components/NavigationList'
+import React, { useContext, useEffect, useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { FlatList } from 'react-native-gesture-handler'
+import { Divider, List, Switch } from 'react-native-paper'
+import { theme } from '../../../../theme'
+import Button from '../../../components/Button'
 import TituloComVoltar from '../../../components/TituloComVoltar'
-import { agendaNotificacaoTeste } from '../../../utils/notificacoes'
+import AuthContext from '../../../context/AuthContext'
+import { AppNavigationProps } from '../../../routes/App.routes'
+import GetAllCanais from '../../../services/notificacoes/getAllCanais'
+import UpdateCanaisUsuario from '../../../services/notificacoes/updateCanaisUsuario'
 
-const Notificacoes = () => {
-  const [notificacaoAtiva, setNotificacaoAtiva] = useState(true)
+const Notificacoes = ({ navigation }: AppNavigationProps) => {
+  const { user, refreshUser } = useContext(AuthContext)
+  const [canaisAtivos, setCanaisAtivos] = useState<string[]>([])
+  const [menus, setMenus] = useState([])
 
-  const toggleNotificacao = () => {
-    setNotificacaoAtiva(!notificacaoAtiva)
-  }
-
-  const handleSolicitaNotificacao = async () => {
-    await agendaNotificacaoTeste()
-  }
-
-  const menu = [
-    {
-      texto: t('perfil.notificaEventos'),
-      onPress: toggleNotificacao,
-      iconeSecundario: (
-        <Switch value={notificacaoAtiva} onValueChange={toggleNotificacao} />
-      )
+  const toggleNotificacao = id => {
+    if (canaisAtivos.includes(id)) {
+      const novosCanais = canaisAtivos.filter(canal => canal !== id)
+      setCanaisAtivos(novosCanais)
+    } else {
+      setCanaisAtivos(current => [...current, id])
     }
-  ]
+  }
+
+  useEffect(() => {
+    const inicializaCanais = async () => {
+      const canais = await new GetAllCanais().call()
+      setMenus(canais)
+      setCanaisAtivos(user.canaisDeNotificacao)
+    }
+    inicializaCanais()
+  }, [])
+
+  const handleSalvar = () => {
+    new UpdateCanaisUsuario().call(user.id, canaisAtivos)
+    refreshUser()
+    navigation.goBack()
+  }
+
+  const Item = ({ item }) => (
+    <List.Item
+      title={t(`notificacoes.canais.${item.nome}`, {
+        defaultValue: item.nome
+      })}
+      titleStyle={styles.texto}
+      right={() => (
+        <Switch
+          value={canaisAtivos.includes(item.id)}
+          onValueChange={() => toggleNotificacao(item.id)}
+        />
+      )}
+      onPress={() => toggleNotificacao(item.id)}
+    />
+  )
+
+  const Divisor = () => (
+    <Divider style={{ backgroundColor: theme.colors.placeholder }} />
+  )
 
   return (
-    <View>
+    <View style={styles.container}>
       <TituloComVoltar texto={t('perfil.notificacoes')} />
-      <NavigationList itens={menu} />
-      <Button onPress={handleSolicitaNotificacao}>Solicita notificação</Button>
+      <FlatList
+        data={menus}
+        renderItem={Item}
+        keyExtractor={item => item.texto}
+        ItemSeparatorComponent={Divisor}
+        ListHeaderComponent={Divisor}
+        ListFooterComponent={Divisor}
+      />
+      <View style={styles.botao}>
+        <Button onPress={handleSalvar}>{t('comum.salvar')}</Button>
+      </View>
     </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  texto: {
+    paddingVertical: 12,
+    paddingLeft: 8,
+    fontSize: 16
+  },
+  botao: {
+    position: 'absolute',
+    bottom: 20,
+    width: '80%',
+    alignSelf: 'center'
+  }
+})
 
 export default Notificacoes

--- a/src/screens/app/perfil/Notificacoes.tsx
+++ b/src/screens/app/perfil/Notificacoes.tsx
@@ -66,7 +66,7 @@ const Notificacoes = ({ navigation }: AppNavigationProps) => {
       <FlatList
         data={menus}
         renderItem={Item}
-        keyExtractor={item => item.texto}
+        keyExtractor={item => item.nome}
         ItemSeparatorComponent={Divisor}
         ListHeaderComponent={Divisor}
         ListFooterComponent={Divisor}

--- a/src/services/notificacoes/getAllCanais.ts
+++ b/src/services/notificacoes/getAllCanais.ts
@@ -1,0 +1,21 @@
+import { ICanalDeNotificacao } from '../../entities/CanalDeNotificacao'
+import CanalDeNotificacaoRepository, {
+  ICanalDeNotificacaoRepository
+} from '../../repositories/CanalDeNotificacaoRepository'
+
+interface IGetAll {
+  call(): Promise<Array<ICanalDeNotificacao>>
+}
+
+export default class GetAllCanais implements IGetAll {
+  private canaisRepository: ICanalDeNotificacaoRepository
+
+  constructor() {
+    this.canaisRepository = new CanalDeNotificacaoRepository()
+  }
+
+  async call(): Promise<Array<ICanalDeNotificacao>> {
+    const canais = await this.canaisRepository.getCanais()
+    return canais
+  }
+}

--- a/src/services/notificacoes/updateCanaisUsuario.ts
+++ b/src/services/notificacoes/updateCanaisUsuario.ts
@@ -1,0 +1,22 @@
+import UsersRepository, {
+  IUsersRepository
+} from '../../repositories/UsersRepository'
+
+interface IUpdateCanaisUsuario {
+  call(userId: string, canaisAtivos: string[]): Promise<void>
+}
+
+export default class UpdateCanaisUsuario implements IUpdateCanaisUsuario {
+  private userRepository: IUsersRepository
+
+  constructor() {
+    this.userRepository = new UsersRepository()
+  }
+
+  async call(userId: string, canaisAtivos: string[]): Promise<void> {
+    this.userRepository.update({
+      id: userId,
+      attributes: { canaisDeNotificacao: canaisAtivos }
+    })
+  }
+}

--- a/src/services/user/RegistrarAcesso.ts
+++ b/src/services/user/RegistrarAcesso.ts
@@ -7,11 +7,11 @@ import {
   cancelaNotificacoesAgendadas
 } from '../../utils/notificacoes'
 
-interface IRegistrarAccesso {
+interface IRegistrarAcesso {
   call(user: IUser): Promise<void>
 }
 
-export default class RegistrarAccesso implements IRegistrarAccesso {
+export default class RegistrarAcesso implements IRegistrarAcesso {
   private usersRepository: IUsersRepository
 
   constructor() {

--- a/src/services/user/SignInUser.ts
+++ b/src/services/user/SignInUser.ts
@@ -1,6 +1,7 @@
 import firebase from 'firebase/app'
 import { auth } from '../../firebase/firebase.config'
 import { agendaNotificacaoTresDias } from '../../utils/notificacoes'
+import UpdateUserTokens from './UpdateUserTokens'
 
 interface ISignInUser {
   call(email: string, password: string): Promise<firebase.auth.UserCredential>
@@ -13,6 +14,7 @@ export default class SignInUser implements ISignInUser {
   ): Promise<firebase.auth.UserCredential> {
     const credenciais = await auth.signInWithEmailAndPassword(email, password)
     agendaNotificacaoTresDias()
+    await new UpdateUserTokens().add(credenciais.user.uid)
     return credenciais
   }
 }

--- a/src/services/user/SignOutUser.ts
+++ b/src/services/user/SignOutUser.ts
@@ -1,5 +1,6 @@
 import { auth } from '../../firebase/firebase.config'
 import { cancelaNotificacoesAgendadas } from '../../utils/notificacoes'
+import UpdateUserTokens from './UpdateUserTokens'
 
 interface ISignOutUser {
   call(): Promise<void>
@@ -8,6 +9,8 @@ interface ISignOutUser {
 export default class SignOutUser implements ISignOutUser {
   async call(): Promise<void> {
     await cancelaNotificacoesAgendadas()
+    const userId = auth.currentUser.uid
+    await new UpdateUserTokens().remove(userId)
     return auth.signOut()
   }
 }

--- a/src/services/user/UpdateUserTokens.ts
+++ b/src/services/user/UpdateUserTokens.ts
@@ -1,0 +1,45 @@
+import { IUser } from '../../entities/User'
+import UsersRepository, {
+  IUsersRepository
+} from '../../repositories/UsersRepository'
+import {
+  Notifications,
+  registraTokenParaNotificacoesExternas
+} from '../../utils/notificacoes'
+
+interface IUpdateUserTokens {
+  add(userId: string): Promise<void>
+  remove(userId: string): Promise<void>
+}
+
+export default class UpdateUserTokens implements IUpdateUserTokens {
+  private userRepository: IUsersRepository
+  constructor() {
+    this.userRepository = new UsersRepository()
+  }
+
+  async add(userId: string): Promise<void> {
+    const token = await registraTokenParaNotificacoesExternas()
+    if (token) {
+      const user = await this.userRepository.getById(userId)
+
+      const novosTokens = [...user.tokens, token]
+      this.userRepository.update({
+        id: userId,
+        attributes: { tokens: novosTokens }
+      })
+    }
+  }
+
+  async remove(userId: string): Promise<void> {
+    const token = (await Notifications.getExpoPushTokenAsync()).data
+    const user = await this.userRepository.getById(userId)
+    const novosTokens = user.tokens?.filter(userToken => userToken !== token)
+    if (token && novosTokens) {
+      this.userRepository.update({
+        id: userId,
+        attributes: { tokens: novosTokens }
+      })
+    }
+  }
+}

--- a/src/utils/notificacoes.ts
+++ b/src/utils/notificacoes.ts
@@ -32,26 +32,8 @@ async function agendaNotificacaoTresDias() {
   })
 }
 
-async function agendaNotificacaoTeste() {
-  await Notifications.scheduleNotificationAsync({
-    content: {
-      title: t('nomeApp'),
-      body: t('notificacoes.tresDias'),
-      data: {
-        link: 'meditacao',
-        params: {
-          id: '7rf0w5Y8E2jiGNUp7xpG'
-        }
-      }
-    },
-    trigger: {
-      seconds: 5
-    }
-  })
-}
-
 async function registraTokenParaNotificacoesExternas() {
-  let token
+  let token: string
   if (Constants.isDevice) {
     const { status: existingStatus } = await Notifications.getPermissionsAsync()
     let finalStatus = existingStatus
@@ -60,7 +42,7 @@ async function registraTokenParaNotificacoesExternas() {
       finalStatus = status
     }
     if (finalStatus !== 'granted') {
-      alert('Failed to get push token for push notification!')
+      console.log('Erro ao registrar token para notificações push')
       return
     }
     token = (await Notifications.getExpoPushTokenAsync()).data
@@ -82,7 +64,6 @@ async function cancelaNotificacoesAgendadas() {
 export {
   Notifications,
   agendaNotificacaoTresDias,
-  agendaNotificacaoTeste,
   registraTokenParaNotificacoesExternas,
   cancelaNotificacoesAgendadas
 }


### PR DESCRIPTION
Adiciona controle de tokens e das inscrições nos canais de notificação 

Esse PR gerencia os tokens para envio de notificações push implementado no  PR [#127](https://github.com/grupotesseract/jornadasolar/pull/127) do projeto pwa

Para testar o expo cli precisa estar logado com um usuário
Verifique se está logado com o comando `expo whoami` e se não estiver faça login rodando `expo login --username [string] --password [string]`


Closes JOR-92