### PR TITLE
fix: reproduz som no modo silencioso do ios

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -12,13 +12,20 @@ interface Props {
   onPlayChange: (boolean) => void
 }
 
-const AudioPlayer = ({ source, onPlayChange }: Props) => {
+const AudioPlayer = ({ source, onPlayChange }: Props): React.ReactElement => {
   const [isPlaying, setIsPlaying] = useState(false)
   const [erro, setErro] = useState(false)
   const [progress, setProgress] = useState(0)
   const [duracao, setDuracao] = useState(0)
   const iconePlayPause = isPlaying ? 'pause' : 'play'
   const [sound, setSound] = useState(new Audio.Sound())
+
+  const setAudioMode = async () => {
+    await Audio.setAudioModeAsync({
+      interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
+      playsInSilentModeIOS: true
+    })
+  }
 
   const loadSound = async () => {
     sound
@@ -52,6 +59,7 @@ const AudioPlayer = ({ source, onPlayChange }: Props) => {
   }, [isPlaying])
 
   useEffect(() => {
+    setAudioMode()
     loadSound().then(() =>
       sound.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)
     )


### PR DESCRIPTION
## O que esse PR altera?

- Configura o modo de áudio do expo-av para reproduzir o som mesmo no modo silencioso do iPhone.

## Como testar

- Em um iPhone, executar uma meditação, variar o modo silencioso entre ligado e desligado e verificar se o som continua saindo.

Closes JOR-116