### PR TITLE
feat: tira registro de token da criação do usuário

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,10 +16,10 @@ import './src/i18n'
 import { Routes } from './src/routes'
 import { AuthProvider } from './src/context/AuthContext'
 import * as Notifications from 'expo-notifications'
-import { Subscription } from '@unimodules/react-native-adapter'
+import { Subscription } from 'expo-modules-core'
 import * as Linking from 'expo-linking'
 
-export default function App() {
+export default function App(): React.ReactElement {
   const [fontsLoaded, error] = useFonts({
     NunitoSans_300Light,
     NunitoSans_400Regular,

--- a/src/components/ModalAceiteLgpd.tsx
+++ b/src/components/ModalAceiteLgpd.tsx
@@ -6,9 +6,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { theme } from '../../theme'
 import AuthContext from '../context/AuthContext'
 import AceitarPoliticaPrivacidade from '../services/user/AceitarPoliticaPrivacidade'
+import UpdateUserTokens from '../services/user/UpdateUserTokens'
 import TextButton from './TextButton'
 
-const ModalAceiteLgpd = () => {
+const ModalAceiteLgpd = (): React.ReactElement => {
   const { userId } = useContext(AuthContext)
   const [isOpen, setIsOpen] = useState(true)
   const insets = useSafeAreaInsets()
@@ -19,6 +20,7 @@ const ModalAceiteLgpd = () => {
 
   const handlePressOk = async () => {
     await new AceitarPoliticaPrivacidade().call(userId)
+    await new UpdateUserTokens().add(userId)
     fechaModal()
   }
 
@@ -45,12 +47,13 @@ const ModalAceiteLgpd = () => {
               <TextButton
                 texto={t('aceitePolitica.conheca')}
                 onPress={handleVerPolitica}
-                testID="BotaoVerPolitica"                
+                testID="BotaoVerPolitica"
               />
             </View>
             <Button
               onPress={handlePressOk}
               testID="BotaoOk"
+              accessibilityLabel="BotaoOk"
               mode="contained"
               style={styles.okButton}
             >

--- a/src/repositories/UsersRepository.ts
+++ b/src/repositories/UsersRepository.ts
@@ -12,7 +12,6 @@ import GetUserSentimentos from '../services/user/GetUserSentimentos'
 import UserFactory, { IUserFactory } from '../factories/UserFactory'
 import { isSameDay } from 'date-fns'
 import GetAllCanais from '../services/notificacoes/getAllCanais'
-import { registraTokenParaNotificacoesExternas } from '../utils/notificacoes'
 
 interface ICreateParameters {
   nome: string
@@ -64,10 +63,9 @@ export default class UsersRepository implements IUsersRepository {
       displayName: nome
     })
 
-    // Inscreve o usuário em todos os canais de notificação e registra o ExpoToken
+    // Inscreve o usuário em todos os canais de notificação
     const canais = await new GetAllCanais().call()
     const idsCanais = canais.map(canal => canal.id)
-    const token = await registraTokenParaNotificacoesExternas()
 
     // Cria usuário na collection user
     const data = {
@@ -80,12 +78,12 @@ export default class UsersRepository implements IUsersRepository {
       lastAccess: now,
       countAccess: 1,
       canaisDeNotificacao: idsCanais,
-      tokens: [token],
       idioma
     }
     await this.collection.doc(user.uid).set(data)
 
-    // Cria subcollection de gruposDeHabitos com subcollection de habitos na collection user
+    // Cria subcollection de gruposDeHabitos com subcollection de habitos
+    // na collection user
     const gruposDeHabitosModelos =
       await new GetAllGruposDeHabitosModelos().call()
     gruposDeHabitosModelos.forEach(async grupoDeHabitoModelo => {
@@ -95,7 +93,8 @@ export default class UsersRepository implements IUsersRepository {
       })
     })
 
-    // Busca grupos de hábitos do usuário e atualiza o gruposDeHabitos que vão pro registro com os ids
+    // Busca grupos de hábitos do usuário e atualiza os gruposDeHabitos que vão
+    // pro registro com os ids
     const gruposDeHabitosDoUsuario = await GetUserGruposDeHabitos(user.uid)
     const gruposDeHabitosAtualizados = gruposDeHabitos.map(grupoDeHabito => {
       const grupoDoUsuario = gruposDeHabitosDoUsuario.find(
@@ -134,7 +133,8 @@ export default class UsersRepository implements IUsersRepository {
       })
     })
 
-    // Busca sentimentos do usuário e atualiza o sentimentos que vão pro registro com os ids
+    // Busca sentimentos do usuário e atualiza os sentimentos que vão pro
+    // registro com os ids
     const sentimentosDoUsuario = await new GetUserSentimentos(user.uid).call()
     const sentimentosAtualizado = sentimentos.map(sentimento => {
       const sentimentoUsuario = sentimentosDoUsuario.find(

--- a/src/services/user/UpdateUserTokens.ts
+++ b/src/services/user/UpdateUserTokens.ts
@@ -31,16 +31,22 @@ export default class UpdateUserTokens implements IUpdateUserTokens {
   }
 
   async remove(userId: string): Promise<void> {
-    const token = await Notifications.getExpoPushTokenAsync()
-    const user = await this.userRepository.getById(userId)
-    const novosTokens = user.tokens?.filter(
-      userToken => userToken !== token.data
-    )
-    if (token && novosTokens) {
-      this.userRepository.update({
-        id: userId,
-        attributes: { tokens: novosTokens }
-      })
+    try {
+      const token = (await Notifications.getExpoPushTokenAsync()).data
+      if (token) {
+        const user = await this.userRepository.getById(userId)
+        const novosTokens = user.tokens?.filter(
+          userToken => userToken !== token
+        )
+        this.userRepository.update({
+          id: userId,
+          attributes: { tokens: novosTokens }
+        })
+      }
+    } catch (e) {
+      throw new Error(
+        'Ocorreu um erro inesperado ao remover o token para notificações: ' + e
+      )
     }
   }
 }

--- a/src/utils/notificacoes.ts
+++ b/src/utils/notificacoes.ts
@@ -1,5 +1,4 @@
 import * as Notifications from 'expo-notifications'
-import Constants from 'expo-constants'
 import { Platform } from 'react-native'
 import add from 'date-fns/add'
 import { t } from 'i18n-js'
@@ -72,26 +71,30 @@ async function agendaNotificacaoQuinzeDias(): Promise<void> {
 
 async function registraTokenParaNotificacoesExternas(): Promise<string> {
   let token: string
-  if (Constants.isDevice) {
+  try {
     const { status: existingStatus } = await Notifications.getPermissionsAsync()
     let finalStatus = existingStatus
+
     if (existingStatus !== 'granted') {
       const { status } = await Notifications.requestPermissionsAsync()
       finalStatus = status
     }
     if (finalStatus !== 'granted') {
-      console.log('Erro ao registrar token para notificações push')
       return
     }
-    token = (await Notifications.getExpoPushTokenAsync())?.data
+
+    token = (await Notifications.getExpoPushTokenAsync()).data
+
+    if (Platform.OS === 'android') {
+      Notifications.setNotificationChannelAsync('Jornada', {
+        name: 'Jornada Solar',
+        importance: Notifications.AndroidImportance.MAX
+      })
+    }
+  } catch (e) {
+    token = ''
   }
 
-  if (Platform.OS === 'android') {
-    Notifications.setNotificationChannelAsync('Jornada', {
-      name: 'Jornada Solar',
-      importance: Notifications.AndroidImportance.MAX
-    })
-  }
   return token
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,9 +4050,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001248, caniuse-lite@^1.0.30001286:
-  version "1.0.30001301"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz#ebc9086026534cab0dab99425d9c3b4425e5f450"
-  integrity sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==
+  version "1.0.30001303"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz"
+  integrity sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## O que esse PR altera?

- Tira o registro do token para notificações externas do processo de criação do usuário e coloca depois do aceite da politica de privacidade.
- A intenção com essa mudança é evitar que os erros ocasionais que aconteçam no registro do token prejudiquem o cadastro do usuário

## Como testar

- Realizar o processo de cadastro e aceite de política e verificar o registro do token no usuário 

Closes JOR-127